### PR TITLE
Fix a typo in ros.md file

### DIFF
--- a/docs/common/dev/ros.md
+++ b/docs/common/dev/ros.md
@@ -1,6 +1,6 @@
 ## ROS
 
-Emlid Raspbian images comes with pre-installed ROS.
+Emlid Raspbian image comes with pre-installed ROS.
 
 ## Basic understanding
 


### PR DESCRIPTION
Fix a typo in docs: common: dev: ros.md